### PR TITLE
Stdin

### DIFF
--- a/rfcfold
+++ b/rfcfold
@@ -365,7 +365,7 @@ process_input() {
   elif [[ ! -r "$infile" ]]; then
     err "specified infile '$infile' cannot be read."
     exit 1
-  elif [[ ! -f "$infile" ]]; then
+  elif [[ ! -f "$infile" ]] || [[ "$infile" == "/dev/stdin" ]]; then
     dbg "specified infile '$infile' is not a regular file."
     temp_infile=$(mktemp)
     dbg "writing infile to temporary file."

--- a/rfcfold
+++ b/rfcfold
@@ -373,6 +373,10 @@ process_input() {
     infile=$temp_infile
   fi
 
+  if [[ ! -s "$infile" ]]; then
+    warn "infile '$infile' is empty."
+  fi
+
   if [[ "$col_gvn" -eq 1 ]] && [[ "$reversed" -eq 1 ]]; then
     warn "'-c' option ignored when unfolding (option '-r')."
   fi

--- a/rfcfold
+++ b/rfcfold
@@ -76,6 +76,7 @@ col_gvn=0  # maxcol overridden?
 hdr_txt_1="NOTE: '\\' line wrapping per RFC 8792"
 hdr_txt_2="NOTE: '\\\\' line wrapping per RFC 8792"
 temp_dir=""
+temp_infile=""
 prog_name='rfcfold'
 prog_version='1.1.0'
 
@@ -110,7 +111,7 @@ type gsed > /dev/null 2>&1 && SED=gsed || SED=sed
 warn 'not using GNU `sed` (likely cause if an error occurs).'
 
 cleanup() {
-  rm -rf "$temp_dir"
+  rm -rf "$temp_dir" "$temp_infile"
 }
 trap 'cleanup' EXIT
 
@@ -358,9 +359,18 @@ process_input() {
     exit 1
   fi
 
-  if [[ ! -f "$infile" ]]; then
-    err "specified file '$infile' does not exist."
+  if [[ ! -e "$infile" ]]; then
+    err "specified infile '$infile' does not exist."
     exit 1
+  elif [[ ! -r "$infile" ]]; then
+    err "specified infile '$infile' cannot be read."
+    exit 1
+  elif [[ ! -f "$infile" ]]; then
+    dbg "specified infile '$infile' is not a regular file."
+    temp_infile=$(mktemp)
+    dbg "writing infile to temporary file."
+    cat "$infile" > "$temp_infile"
+    infile=$temp_infile
   fi
 
   if [[ "$col_gvn" -eq 1 ]] && [[ "$reversed" -eq 1 ]]; then


### PR DESCRIPTION
Implement reading from standard input (STDIN).

If data is read from standard input instead of from a regular file, write all data to a temporary file, and then process that temporary file. The temporary file is deleted afterwards.

At least some operating systems provide a special file called `/dev/stdin` that allows using standard input where a regular file is expected. The Bash shell emulates this if it is missing from the operating system. Thus anywhere the Bash script `rfcfold` can be used, this mechanism can be used as well.

I have tested the code on Ubuntu GNU/Linux, starting `rfcfold` from both a Bash and a dash shell.

This pull request addresses issue #3