### PR TITLE
adjust sed scripts to conform to POSIX wording

### DIFF
--- a/rfcfold
+++ b/rfcfold
@@ -105,10 +105,6 @@ dbg() {
 # determine name of [g]sed binary
 type gsed > /dev/null 2>&1 && SED=gsed || SED=sed
 
-# warn if a non-GNU sed utility is used
-"$SED" --version < /dev/null 2> /dev/null | grep -q GNU || \
-warn 'not using GNU `sed` (likely cause if an error occurs).'
-
 cleanup() {
   rm -rf "$temp_dir"
 }

--- a/rfcfold
+++ b/rfcfold
@@ -154,8 +154,11 @@ fold_it_1() {
   # generate outfile
   printf -- '%s\n' "$header" > "$outfile"
   echo "" >> "$outfile"
-  "$SED" 's/\(.\{'"$foldcol"'\}\)\(..\)/\1\\\n\2/;t M;b;:M;P;D'\
-    < "$infile" >> "$outfile" 2> /dev/null
+  "$SED" 's/\(.\{'"$foldcol"'\}\)\(..\)/\1\\\
+\2/;t M
+    b
+    :M
+    P;D' < "$infile" >> "$outfile" 2> /dev/null
   if [[ $? -ne 0 ]]; then
     return 1
   fi
@@ -167,7 +170,9 @@ fold_it_2() {
   foldcol=$(expr "$maxcol" - 1) # for the inserted '\' char
 
   # ensure input file doesn't contain the fold-sequence already
-  if [[ -n "$("$SED" -n '/\\$/{N;s/\\\n[ ]*\\/&/p;D}' "$infile")" ]]
+  if [[ -n "$("$SED" -n '/\\$/{
+                N;s/\\\n[ ]*\\/&/p;D
+              }' "$infile")" ]]
   then
     err "infile '$infile' has a line ending with a '\\' character"\
         "followed by a '\\' character as the first non-space"\
@@ -187,8 +192,11 @@ fold_it_2() {
   # generate outfile
   printf -- '%s\n' "$header" > "$outfile"
   echo "" >> "$outfile"
-  "$SED" 's/\(.\{'"$foldcol"'\}\)\(..\)/\1\\\n\\\2/;t M;b;:M;P;D'\
-    < "$infile" >> "$outfile" 2> /dev/null
+  "$SED" 's/\(.\{'"$foldcol"'\}\)\(..\)/\1\\\
+\\\2/;t M
+    b
+    :M
+    P;D' < "$infile" >> "$outfile" 2> /dev/null
   if [[ $? -ne 0 ]]; then
     return 1
   fi
@@ -254,7 +262,9 @@ unfold_it_1() {
   awk "NR>2" "$infile" > "$temp_dir/wip"
 
   # unfold wip file
-  "$SED" '{H;$!d};x;s/^\n//;s/\\\n *//g' "$temp_dir/wip" > "$outfile"
+  "$SED" '{
+      H;$!d
+    };x;s/^\n//;s/\\\n *//g' "$temp_dir/wip" > "$outfile"
 
   return $?
 }
@@ -266,8 +276,9 @@ unfold_it_2() {
   awk "NR>2" "$infile" > "$temp_dir/wip"
 
   # unfold wip file
-  "$SED" '{H;$!d};x;s/^\n//;s/\\\n *\\//g' "$temp_dir/wip"\
-    > "$outfile"
+  "$SED" '{
+      H;$!d
+    };x;s/^\n//;s/\\\n *\\//g' "$temp_dir/wip" > "$outfile"
 
   return $?
 }


### PR DESCRIPTION
This addresses two compatibility issues:

  1. The substitution part of an s command cannot portably contain
     the escape sequence '\n', but must use an embedded newline
     instead.

  2. Some sed commands may not be terminated with a semicolon, but
     must be terminated with a newline.

This is similar, but not identical, to sed script changes tested
successfully on macOS Catalina (10.15.7).  This still works with
GNU sed, but needs to be tested with macOS sed.  Reports of test
results with other "current" sed implementations are welcome, too.

After successfully testing sed script changes for macOS compatibility,
the warning when not using GNU sed should be removed.