### PR TITLE
Address complaints from the static analysis tool ShellCheck

### DIFF
--- a/rfcfold
+++ b/rfcfold
@@ -155,7 +155,8 @@ fold_it_1() {
 \2/;t M
     b
     :M
-    P;D' < "$infile" >> "$outfile" 2> /dev/null; then
+    P;D' < "$infile" >> "$outfile" 2> /dev/null
+  then
     return 1
   fi
   return 0
@@ -193,7 +194,8 @@ fold_it_2() {
 \\\2/;t M
     b
     :M
-    P;D' < "$infile" >> "$outfile" 2> /dev/null; then
+    P;D' < "$infile" >> "$outfile" 2> /dev/null
+  then
     return 1
   fi
   return 0

--- a/rfcfold
+++ b/rfcfold
@@ -82,9 +82,10 @@ prog_version='1.1.0'
 # functions for diagnostic messages
 prog_msg() {
   if [[ "$quiet" -eq 0 ]]; then
-    format_string="${prog_name}: $1: %s\n"
+    local severity
+    severity=$1
     shift
-    printf -- "$format_string" "$*" >&2
+    printf -- '%s: %s: %s\n' "$prog_name" "$severity" "$*" >&2
   fi
 }
 

--- a/rfcfold
+++ b/rfcfold
@@ -286,7 +286,7 @@ unfold_it() {
   # check if file needs unfolding
   line=$(head -n 1 "$infile")
   line2=$("$SED" -n '2p' "$infile")
-  result=$(printf -- '%s\n' "$line" | fgrep "$hdr_txt_1")
+  result=$(printf -- '%s\n' "$line" | grep -F "$hdr_txt_1")
   if [[ $? -eq 0 ]]; then
     if [[ -n "$line2" ]]; then
       err "the second line in '$infile' is not empty."
@@ -295,7 +295,7 @@ unfold_it() {
     unfold_it_1
     return $?
   fi
-  result=$(printf -- '%s\n' "$line" | fgrep "$hdr_txt_2")
+  result=$(printf -- '%s\n' "$line" | grep -F "$hdr_txt_2")
   if [[ $? -eq 0 ]]; then
     if [[ -n "$line2" ]]; then
       err "the second line in '$infile' is not empty."

--- a/rfcfold
+++ b/rfcfold
@@ -130,7 +130,7 @@ fold_it_1() {
   fi
 
   # where to fold
-  foldcol=$(expr "$maxcol" - 1) # for the inserted '\' char
+  foldcol=$((maxcol - 1)) # for the inserted '\' char
 
   # ensure input file doesn't contain whitespace on the fold column
   grep -q "^\(.\{$foldcol\}\)\{1,\} " "$infile"
@@ -142,9 +142,9 @@ fold_it_1() {
   fi
 
   # center header text
-  length=$(expr ${#hdr_txt_1} + 2)
-  left_sp=$(expr \( "$maxcol" - "$length" \) / 2)
-  right_sp=$(expr "$maxcol" - "$length" - "$left_sp")
+  length=$((${#hdr_txt_1} + 2))
+  left_sp=$(( (maxcol - length) / 2 ))
+  right_sp=$((maxcol - length - left_sp))
   header=$(printf -- '%s %s %s' "$(equal_chars "$left_sp")" \
                      "$hdr_txt_1" "$(equal_chars "$right_sp")")
 
@@ -165,7 +165,7 @@ fold_it_1() {
 
 fold_it_2() {
   # where to fold
-  foldcol=$(expr "$maxcol" - 1) # for the inserted '\' char
+  foldcol=$((maxcol - 1)) # for the inserted '\' char
 
   # ensure input file doesn't contain the fold-sequence already
   if [[ -n "$("$SED" -n '/\\$/{
@@ -181,9 +181,9 @@ fold_it_2() {
   fi
 
   # center header text
-  length=$(expr ${#hdr_txt_2} + 2)
-  left_sp=$(expr \( "$maxcol" - "$length" \) / 2)
-  right_sp=$(expr "$maxcol" - "$length" - "$left_sp")
+  length=$((${#hdr_txt_2} + 2))
+  left_sp=$(( (maxcol - length) / 2))
+  right_sp=$((maxcol - length - left_sp))
   header=$(printf -- '%s %s %s' "$(equal_chars "$left_sp")" \
                      "$hdr_txt_2" "$(equal_chars "$right_sp")")
 
@@ -225,7 +225,7 @@ fold_it() {
   fi
 
   # check if file needs folding
-  testcol=$(expr "$maxcol" + 1)
+  testcol=$((maxcol + 1))
   grep -q ".\{$testcol\}" "$infile"
   if [[ $? -ne 0 ]]; then
     dbg "nothing to do; copying infile to outfile."
@@ -378,9 +378,9 @@ process_input() {
   fi
 
   if [[ "$strategy" -eq 0 ]] || [[ "$strategy" -eq 2 ]]; then
-    min_supported=$(expr ${#hdr_txt_2} + 8)
+    min_supported=$((${#hdr_txt_2} + 8))
   else
-    min_supported=$(expr ${#hdr_txt_1} + 8)
+    min_supported=$((${#hdr_txt_1} + 8))
   fi
   if [[ "$maxcol" -lt "$min_supported" ]]; then
     err "the folding column cannot be less than $min_supported."

--- a/rfcfold
+++ b/rfcfold
@@ -151,6 +151,7 @@ fold_it_1() {
   # generate outfile
   printf -- '%s\n' "$header" > "$outfile"
   echo "" >> "$outfile"
+  # shellcheck disable=SC1004
   "$SED" 's/\(.\{'"$foldcol"'\}\)\(..\)/\1\\\
 \2/;t M
     b
@@ -189,6 +190,7 @@ fold_it_2() {
   # generate outfile
   printf -- '%s\n' "$header" > "$outfile"
   echo "" >> "$outfile"
+  # shellcheck disable=SC1004
   "$SED" 's/\(.\{'"$foldcol"'\}\)\(..\)/\1\\\
 \\\2/;t M
     b

--- a/rfcfold
+++ b/rfcfold
@@ -133,8 +133,7 @@ fold_it_1() {
   foldcol=$((maxcol - 1)) # for the inserted '\' char
 
   # ensure input file doesn't contain whitespace on the fold column
-  grep -q "^\(.\{$foldcol\}\)\{1,\} " "$infile"
-  if [[ $? -eq 0 ]]; then
+  if grep -q "^\(.\{$foldcol\}\)\{1,\} " "$infile"; then
     err "infile '$infile' has a space character occurring on the"\
         "folding column.  This file cannot be folded using the"\
         "'\\' strategy."
@@ -152,12 +151,11 @@ fold_it_1() {
   printf -- '%s\n' "$header" > "$outfile"
   echo "" >> "$outfile"
   # shellcheck disable=SC1004
-  "$SED" 's/\(.\{'"$foldcol"'\}\)\(..\)/\1\\\
+  if ! "$SED" 's/\(.\{'"$foldcol"'\}\)\(..\)/\1\\\
 \2/;t M
     b
     :M
-    P;D' < "$infile" >> "$outfile" 2> /dev/null
-  if [[ $? -ne 0 ]]; then
+    P;D' < "$infile" >> "$outfile" 2> /dev/null; then
     return 1
   fi
   return 0
@@ -191,12 +189,11 @@ fold_it_2() {
   printf -- '%s\n' "$header" > "$outfile"
   echo "" >> "$outfile"
   # shellcheck disable=SC1004
-  "$SED" 's/\(.\{'"$foldcol"'\}\)\(..\)/\1\\\
+  if ! "$SED" 's/\(.\{'"$foldcol"'\}\)\(..\)/\1\\\
 \\\2/;t M
     b
     :M
-    P;D' < "$infile" >> "$outfile" 2> /dev/null
-  if [[ $? -ne 0 ]]; then
+    P;D' < "$infile" >> "$outfile" 2> /dev/null; then
     return 1
   fi
   return 0
@@ -204,8 +201,7 @@ fold_it_2() {
 
 fold_it() {
   # ensure input file doesn't contain a tab
-  grep -q $'\t' "$infile"
-  if [[ $? -eq 0 ]]; then
+  if grep -q $'\t' "$infile"; then
     err "infile '$infile' contains a tab character, which is not"\
         "allowed."
     return 1
@@ -226,8 +222,7 @@ fold_it() {
 
   # check if file needs folding
   testcol=$((maxcol + 1))
-  grep -q ".\{$testcol\}" "$infile"
-  if [[ $? -ne 0 ]]; then
+  if ! grep -q ".\{$testcol\}" "$infile"; then
     dbg "nothing to do; copying infile to outfile."
     cp "$infile" "$outfile"
     return 255
@@ -286,8 +281,7 @@ unfold_it() {
   # check if file needs unfolding
   line=$(head -n 1 "$infile")
   line2=$("$SED" -n '2p' "$infile")
-  result=$(printf -- '%s\n' "$line" | grep -F "$hdr_txt_1")
-  if [[ $? -eq 0 ]]; then
+  if result=$(printf -- '%s\n' "$line" | grep -F "$hdr_txt_1"); then
     if [[ -n "$line2" ]]; then
       err "the second line in '$infile' is not empty."
       return 1
@@ -295,8 +289,7 @@ unfold_it() {
     unfold_it_1
     return $?
   fi
-  result=$(printf -- '%s\n' "$line" | grep -F "$hdr_txt_2")
-  if [[ $? -eq 0 ]]; then
+  if result=$(printf -- '%s\n' "$line" | grep -F "$hdr_txt_2"); then
     if [[ -n "$line2" ]]; then
       err "the second line in '$infile' is not empty."
       return 1


### PR DESCRIPTION
The static analysis tool ShellCheck (https://www.shellcheck.net/, https://github.com/koalaman/shellcheck) can help in finding bugs in shell scripts.

To allow a human to actually spot a real issue in the flood of issues reported by static analysis tools, each one needs to be addressed. Addressing should preferably mean following the advice of the tool, even if one would prefer a different style. Since a static analyser cannot reliably infer the intention behind a legal, but *unusual* or even *often erroneous*, but sometimes *required*, construct, some complaints need to be selectively disabled.

This pull request addresses all reports from ShellCheck version 0.4.6 as included in Ubuntu GNU/Linux 18.04:

```
$ shellcheck rfcfold && echo OK
OK
$
```

The modified `rfcfold` still works fine on Ubuntu GNU/Linux. I do not know if it still works on macOS, though.