### PR TITLE
Use GNU grep (ggrep) if available

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Noteworthy Changes in rfcfold Releases
 
+## Upcoming Version
+
+* Prefer [GNU grep](https://www.gnu.org/software/grep/) installed as `ggrep`
+  over the grep included in the operating system, if available.  On some
+  systems, e.g. macOS, this may increase the maximum folding column value for
+  `rfcfold`, if combined with using GNU sed (e.g, as `gsed`).
+
 ## Version 1.2.1 (2020-12-15)
 
 * Update NEWS.md file with current information.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@
 script that folds or unfolds a text file according to
 [RFC 8792](https://www.rfc-editor.org/info/rfc8792),
 *Handling Long Lines in Content of Internet-Drafts and RFCs*.
-The (un)folding operations are implemented with `sed`.
+The (un)folding operations are implemented with `grep` and `sed`.
+
+# Usage
 
 Invoking `rfcfold` with the `-h` option shows usage information.
+
+# `grep` and `sed`
+
+Usage of both
+[grep](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html)
+and
+[sed](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sed.html)
+conforms to the
+[POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/)
+specification.
+
+On non-[GNU](https://www.gnu.org/) systems, GNU tools are often
+installed to complement the system-provided ones.  On such systems,
+[GNU grep](https://www.gnu.org/software/grep/)
+and
+[GNU sed](https://www.gnu.org/software/sed/)
+are used if they are available as `ggrep` and `gsed`.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ script that folds or unfolds a text file according to
 *Handling Long Lines in Content of Internet-Drafts and RFCs*.
 The (un)folding operations are implemented with `grep` and `sed`.
 
-# Usage
+## Usage
 
 Invoking `rfcfold` with the `-h` option shows usage information.
 
-# `grep` and `sed`
+## `grep` and `sed`
 
 Usage of both
 [grep](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/grep.html)

--- a/rfcfold
+++ b/rfcfold
@@ -102,7 +102,7 @@ dbg() {
   fi
 }
 
-# determine name of [g]sed binary
+# prefer gsed (GNU sed) over the system's default sed
 type gsed > /dev/null 2>&1 && SED=gsed || SED=sed
 
 cleanup() {

--- a/rfcfold
+++ b/rfcfold
@@ -104,6 +104,8 @@ dbg() {
 
 # prefer gsed (GNU sed) over the system's default sed
 type gsed > /dev/null 2>&1 && SED=gsed || SED=sed
+# prefer ggrep (GNU grep) over the system's default grep
+type ggrep > /dev/null 2>&1 && GREP=ggrep || GREP=grep
 
 cleanup() {
   rm -rf "$temp_dir"
@@ -132,7 +134,7 @@ fold_it_1() {
   foldcol=$((maxcol - 1)) # for the inserted '\' char
 
   # ensure input file doesn't contain whitespace on the fold column
-  if grep -q "^\(.\{$foldcol\}\)\{1,\} " "$infile"; then
+  if "$GREP" -q "^\(.\{$foldcol\}\)\{1,\} " "$infile"; then
     err "infile '$infile' has a space character occurring on the"\
         "folding column.  This file cannot be folded using the"\
         "'\\' strategy."
@@ -198,7 +200,7 @@ fold_it_2() {
 
 fold_it() {
   # ensure input file doesn't contain a tab
-  if grep -q $'\t' "$infile"; then
+  if "$GREP" -q $'\t' "$infile"; then
     err "infile '$infile' contains a tab character, which is not"\
         "allowed."
     return 1
@@ -219,7 +221,7 @@ fold_it() {
 
   # check if file needs folding
   testcol=$((maxcol + 1))
-  if ! grep -q ".\{$testcol\}" "$infile"; then
+  if ! "$GREP" -q ".\{$testcol\}" "$infile"; then
     dbg "nothing to do; copying infile to outfile."
     cp "$infile" "$outfile"
     return 255
@@ -278,7 +280,8 @@ unfold_it() {
   # check if file needs unfolding
   line=$(head -n 1 "$infile")
   line2=$("$SED" -n '2p' "$infile")
-  if result=$(printf -- '%s\n' "$line" | grep -F "$hdr_txt_1"); then
+  if result=$(printf -- '%s\n' "$line" | "$GREP" -F "$hdr_txt_1")
+  then
     if [[ -n "$line2" ]]; then
       err "the second line in '$infile' is not empty."
       return 1
@@ -286,7 +289,8 @@ unfold_it() {
     unfold_it_1
     return $?
   fi
-  if result=$(printf -- '%s\n' "$line" | grep -F "$hdr_txt_2"); then
+  if result=$(printf -- '%s\n' "$line" | "$GREP" -F "$hdr_txt_2")
+  then
     if [[ -n "$line2" ]]; then
       err "the second line in '$infile' is not empty."
       return 1
@@ -351,6 +355,7 @@ process_input() {
   dbg "$prog_name $prog_version using interpreter $BASH" \
       "version $BASH_VERSION on ${BASH_VERSINFO[5]}"
   dbg "sed binary: $(type "$SED")"
+  dbg "grep binary: $(type "$GREP")"
 
   if [[ -z "$infile" ]]; then
     err "infile parameter missing (use -h for help)."
@@ -382,7 +387,7 @@ process_input() {
   fi
   dbg "testing grep support for folding column value '$maxcol'..."
   # testcol == maxcol + 1
-  echo a | grep -q "a\{1,$((maxcol+1))\}" || {
+  echo a | "$GREP" -q "a\{1,$((maxcol+1))\}" || {
     err "folding column '$maxcol' is too big for grep."
     exit 1
   }


### PR DESCRIPTION
GNU grep allows a larger maximum value for the folding column than, e.g., the grep included in macOS. Prefer GNU grep over the system's grep, if it is installed as `ggrep`.

GNU grep can be used as a drop-in replacement of grep, just as GNU sed can be used as a drop-in replacement of sed.

Using GNU sed (`gsed`) in combination with, e.g., macOS grep, would still limit the maximum folding column to well below 300. Using both GNU sed and GNU grep overcomes this limitation.